### PR TITLE
Fixed wp:heading blocks style problem

### DIFF
--- a/templates/archive-project.html
+++ b/templates/archive-project.html
@@ -15,7 +15,7 @@
                 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
                     <div class="wp-block-group alignwide">
                         <!-- wp:heading {"level":2,"align":"wide","layout":{"inherit":true}} -->
-                        <h2 class="wp-block-heading wp-block-post-title alignwide"><strong>Projects</strong> I am working on, that I want to share</h2>
+                        <h2 class="wp-block-heading alignwide"><strong>Projects</strong> I am working on, that I want to share</h2>
                         <!-- /wp:heading -->
                     </div>
                 <!-- /wp:group -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -15,7 +15,7 @@
                 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
                     <div class="wp-block-group alignwide">
                         <!-- wp:heading {"level":2,"align":"wide","layout":{"inherit":true}} -->
-                        <h2 class="wp-block-heading wp-block-post-title alignwide">I write as a newcomer about <strong>web development</strong>, and <strong>WordPress</strong> full site editing</h2>
+                        <h2 class="wp-block-heading alignwide">I write as a newcomer about <strong>web development</strong>, and <strong>WordPress</strong> full site editing</h2>
                         <!-- /wp:heading -->
                     </div>
                 <!-- /wp:group -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
                 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
                     <div class="wp-block-group alignwide">
                         <!-- wp:heading {"level":2,"align":"wide","layout":{"inherit":true}} -->
-                        <h2 class="wp-block-heading wp-block-post-title alignwide">I write as a newcomer about <strong>web development</strong>, and <strong>WordPress</strong> full site editing</h2>
+                        <h2 class="wp-block-heading alignwide">I write as a newcomer about <strong>web development</strong>, and <strong>WordPress</strong> full site editing</h2>
                         <!-- /wp:heading -->
                     </div>
                 <!-- /wp:group -->

--- a/templates/page-about.html
+++ b/templates/page-about.html
@@ -15,7 +15,7 @@
                 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
                     <div class="wp-block-group alignwide">
                         <!-- wp:heading {"level":2,"align":"wide","layout":{"inherit":true}} -->
-                            <h2 class="wp-block-heading wp-block-post-title alignwide">I work as a <strong>web developer</strong>, and my goal is to make products <strong>honest</strong>, <strong>accessible</strong>, and <strong>inclusive</strong></h2>
+                            <h2 class="wp-block-heading alignwide">I work as a <strong>web developer</strong>, and my goal is to make products <strong>honest</strong>, <strong>accessible</strong>, and <strong>inclusive</strong></h2>
                         <!-- /wp:heading -->
                     </div>
                 <!-- /wp:group -->

--- a/templates/page-home.html
+++ b/templates/page-home.html
@@ -15,7 +15,7 @@
                 <!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
                     <div class="wp-block-group alignwide">
                         <!-- wp:heading {"level":2,"align":"wide","layout":{"inherit":true}} -->
-                            <h2 class="wp-block-heading wp-block-post-title alignwide">I write as a newcomer about <strong>web development</strong>, and <strong>WordPress</strong> full site editing</h2>
+                            <h2 class="wp-block-heading alignwide">I write as a newcomer about <strong>web development</strong>, and <strong>WordPress</strong> full site editing</h2>
                         <!-- /wp:heading -->
                     </div>
                 <!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -227,6 +227,37 @@
                     "text": "var(--wp--preset--color--contrast)"
                 }
             },
+            "core/heading": {
+                "color": {
+                    "background": "var(--wp--preset--color--contrast)",
+                    "text": "var(--wp--preset--color--background)"
+                },
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--mega)",
+                    "fontWeight": "400",
+                    "lineHeight": "var(--wp--custom--line-height--mega)"
+                },
+                "spacing": {
+                    "padding": {
+                        "top": "calc(var(--wp--custom--grid--base)*1)",
+                        "bottom": "calc(var(--wp--custom--grid--base)*0)"
+                    },
+                    "margin": {
+                        "top": "0",
+                        "bottom": "0"
+                    }
+                },
+                "elements": {
+                    "link": {
+                        "color": {
+                            "text": "inherit"
+                        },
+                        "typography": {
+                            "textDecoration": "none"
+                        }
+                    }
+                }
+            },
             "core/post-title": {
                 "color": {
                     "background": "var(--wp--preset--color--contrast)",


### PR DESCRIPTION
After updating to WordPress 6.1, `wp:heading` blocks were not being displayed correctly.

Why?
Because instead of applying the same styles in `theme.json` for `wp:heading` and `wp:post-title` i just added `.wp-block-post-title` class in the templates.

With the last update, on pages, styles for `wp:post-title` were not loading anymore. It is probably by design, as not including unnecessary styles improves performance; but I could not find any documentation on the change.

Solution
Applied the styles to `wp:heading` in `theme.json`, so they will load accordingly.